### PR TITLE
[EHZ] Added sorting features to personal page

### DIFF
--- a/auto-imports.d.ts
+++ b/auto-imports.d.ts
@@ -40,6 +40,7 @@ declare global {
   const getPointFromProblem: typeof import('./src/composables/utils')['getPointFromProblem']
   const getPointFromProblemId: typeof import('./src/composables/utils')['getPointFromProblemId']
   const getPoints: typeof import('./src/composables/utils')['getPoints']
+  const getSolvedMultiplier: typeof import('./src/composables/utils')['getSolvedMultiplier']
   const getTableData: typeof import('./src/composables/utils')['getTableData']
   const getUpsolveMultiplier: typeof import('./src/composables/utils')['getUpsolveMultiplier']
   const h: typeof import('vue')['h']
@@ -327,6 +328,7 @@ declare module 'vue' {
     readonly getPointFromProblem: UnwrapRef<typeof import('./src/composables/utils')['getPointFromProblem']>
     readonly getPointFromProblemId: UnwrapRef<typeof import('./src/composables/utils')['getPointFromProblemId']>
     readonly getPoints: UnwrapRef<typeof import('./src/composables/utils')['getPoints']>
+    readonly getSolvedMultiplier: UnwrapRef<typeof import('./src/composables/utils')['getSolvedMultiplier']>
     readonly getTableData: UnwrapRef<typeof import('./src/composables/utils')['getTableData']>
     readonly getUpsolveMultiplier: UnwrapRef<typeof import('./src/composables/utils')['getUpsolveMultiplier']>
     readonly h: UnwrapRef<typeof import('vue')['h']>

--- a/src/pages/[username].vue
+++ b/src/pages/[username].vue
@@ -42,17 +42,50 @@ const handle = handles.find(handle => handle.username === props.username)!
 const codeforces_handles_lower = handle.codeforces_handles.map((handle: string) => handle.toLowerCase())
 const atcoder_handles_lower = handle.atcoder_handles.map((handle: string) => handle.toLowerCase())
 
-const userCFSubmissions = submissions.filter(submission =>
-  (submission.platform === 'codeforces' && codeforces_handles_lower.includes(submission.handle.toLowerCase()))).reverse()
+const  userCFSubmissions= reactive(submissions.filter(submission =>
+  (submission.platform === 'codeforces' && codeforces_handles_lower.includes(submission.handle.toLowerCase()))).reverse())
 
-const userATsubmissions = submissions.filter(submission =>
-  (submission.platform === 'atcoder' && atcoder_handles_lower.includes(submission.handle.toLowerCase()))).reverse()
+const userATsubmissions = reactive(submissions.filter(submission =>
+  (submission.platform === 'atcoder' && atcoder_handles_lower.includes(submission.handle.toLowerCase()))).reverse())
 
-const userICPCsubmissions = submissions.filter(submission =>
-  (submission.platform === 'icpc' && submission.solved && codeforces_handles_lower.includes(submission.handle.toLowerCase()))).reverse()
+const userICPCsubmissions = reactive(submissions.filter(submission =>
+  (submission.platform === 'icpc' && submission.solved && codeforces_handles_lower.includes(submission.handle.toLowerCase()))).reverse())
 
 const userZealotssubmissions = submissions.filter(submission =>
   (submission.platform === 'zealots' && codeforces_handles_lower.includes(submission.handle.toLowerCase()))).reverse()
+
+const sortTable = (val: string, data: any)=> {
+    if (val === 'Contest ID' && data !== userICPCsubmissions) {
+      data.sort((a: any, b: any) => b.contest_id - a.contest_id);
+    } else if (val === 'Contest ID' && data === userICPCsubmissions){
+      data.sort((a: any, b: any) => (getLast(b.contest_id as string) as any) - (getLast(a.contest_id as string) as any)); 
+    } else if (val === 'Rating') {
+      data.sort((a: any, b: any) => b.rating - a.rating);
+    } else if (val === 'Solved Time') {
+      data.sort((a: any, b: any) => b.time - a.time);
+    } else if (val === 'Upsolved') {
+      data.sort((a: any, b: any) => a.upsolved - b.upsolved);
+    } else if (val === 'Division') {
+      data.sort((a: any, b: any) => a.division - b.division);
+    } else if (val === 'Points' && data === userCFSubmissions){
+      data.sort((a: any, b: any) => getPointFromProblem(b.upsolved, b.division, b.problem_id, b.platform) - getPointFromProblem(a.upsolved, a.division, a.problem_id, a.platform));
+    } else if (val === 'Points' && data === userATsubmissions){
+      data.sort((a: any, b: any) => getPointFromProblemId(b.problem_id, b.platform) - getPointFromProblemId(a.problem_id, a.platform));
+    } else if (val === 'Points' && data === userICPCsubmissions)
+      data.sort((a: any, b: any) => getPointFromProblem(b.upsolved, 0, "", "icpc") - getPointFromProblem(a.upsolved, 0, "", "icpc"));
+  }
+const sorteduserCFSubmissions = computed(() => {
+  return userCFSubmissions
+})
+
+const sorteduserATsubmissions = computed(() => {
+  return userATsubmissions
+})
+
+const sorteduserICPCsubmissions = computed(() => {
+  return userICPCsubmissions
+})
+
 </script>
 
 <template>
@@ -74,11 +107,12 @@ const userZealotssubmissions = submissions.filter(submission =>
       </p>
       <table border-1 m-auto m-y-5>
         <tr border-1>
-          <th v-for="val in codeforcesTitles" :key="val" border-1>
+          <th v-for="val in codeforcesTitles" :key="val" border-1 @click="sortTable(val, userCFSubmissions)">
             {{ val }}
+            <span v-if="val !== 'Handle' && val !== 'Problem ID'">&#8597;</span>
           </th>
         </tr>
-        <tr v-for="(userData, index) in userCFSubmissions" :key="index" border-1>
+        <tr v-for="(userData, index) in sorteduserCFSubmissions" :key="index" border-1>
           <td border-1>
             <a :href="`https://codeforces.com/profile/${userData.handle}`" target="_blank">
               {{ userData.handle }}
@@ -130,11 +164,12 @@ const userZealotssubmissions = submissions.filter(submission =>
       </p>
       <table border-1 m-auto m-y-5>
         <tr border-1>
-          <th v-for="val in tableTitles" :key="val" border-1>
+          <th v-for="val in tableTitles" :key="val" border-1 @click="sortTable(val, userATsubmissions)">
             {{ val }}
+            <span v-if="val !== 'Handle' && val !== 'Problem ID'">&#8597;</span>
           </th>
         </tr>
-        <tr v-for="(userData, index) in userATsubmissions" :key="index" border-1>
+        <tr v-for="(userData, index) in sorteduserATsubmissions" :key="index" border-1>
           <td border-1>
             <a :href="`https://atcoder.jp/users/${userData.handle}`" target="_blank">
               {{ userData.handle }}
@@ -172,11 +207,12 @@ const userZealotssubmissions = submissions.filter(submission =>
       </p>
       <table border-1 m-auto m-y-5>
         <tr border-1>
-          <th v-for="val in icpcTitles" :key="val" border-1>
+          <th v-for="val in icpcTitles" :key="val" border-1 @click="sortTable(val, userICPCsubmissions)">
             {{ val }}
+            <span v-if="val !== 'Handle' && val !== 'Problem ID'">&#8597;</span>
           </th>
         </tr>
-        <tr v-for="(userData, index) in userICPCsubmissions" :key="index" border-1>
+        <tr v-for="(userData, index) in sorteduserICPCsubmissions" :key="index" border-1>
           <td border-1>
             <a :href="`https://codeforces.com/profile/${userData.handle}`" target="_blank">
               {{ userData.handle }}


### PR DESCRIPTION
Hello, I often need to search for specific information while using cp-ranking, such as which problems were solved in a particular contest, or what is the highest Rating I have achieved. To improve the efficiency of visualizing data in cp-ranking, I have added sorting functionality for each column in the displays of **codeforces live contest**, **Atcoder**, and **ICPC practice contests**.

## Description
- **Which sections can be sorted**: Codeforces, Atcoder, ICPC on personal page.
- **Which columns can be sorted**: All columns except from `Handle` and `Problem ID`, since I don't consider sorting these useful. A &#8597; is tagged to the column with sorting feature.
- **How to sort**: Click on the column name. The logic is basically from hard to easy and from recent to former
  - Contest ID: decreasing
  - Rating: decreasing
  - Solved Time: recent -> former
  - Upsolved: false -> true
  - Division: increasing
  - Points: dereasing

## Examples
Original (sort by time)
<img width="982" alt="image" src="https://user-images.githubusercontent.com/56754826/236564991-0275629a-ab8f-42e8-b4c1-7e79836e6176.png">
sort by contest ID (contests regardless of upsolving status are gathered)
<img width="971" alt="image" src="https://user-images.githubusercontent.com/56754826/236565430-b13db0a1-c9e4-4f23-8d51-08a68061d0da.png">
sort by rating
<img width="968" alt="image" src="https://user-images.githubusercontent.com/56754826/236565658-f7cdf87d-2000-4327-b7c4-fb50e687947f.png">
sort by whether upsolved
<img width="969" alt="image" src="https://user-images.githubusercontent.com/56754826/236565784-1c4872d8-37ef-443d-81ce-bff60fc0320f.png">
sort by division
<img width="973" alt="image" src="https://user-images.githubusercontent.com/56754826/236565860-e20ca80c-271b-45c6-bf52-8082897c030e.png">
sort by points
<img width="970" alt="image" src="https://user-images.githubusercontent.com/56754826/236565942-3f6bfebc-e438-44a8-a04b-b55d3b8b6978.png">

## Test
- Looks good on Vite with `npm run dev` (but I haven't tested with the deployment)
- No conflict when clicking multiple columns in the same section (the last click is valid)
- No conflict when clicking multiple columns in different sections (changes in different sections will remain)

If you could consider adding the aforementioned feature or provide suggestions regarding it, I would be very grateful~